### PR TITLE
composer require 安装的版本有误

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## 安装
 
 ```
-composer require ibrand/laravel-wechat-platform:~1.0 -vvv
+composer require ibrand/laravel-wechat-platform:dev-master -vvv
 ```
 
 低于 Laravel5.5 版本


### PR DESCRIPTION
原安装命令行使用的是 `https://packagist.org/packages/ibrand/laravel-wechat-platform#v1.0.6 `
应改为
```
composer require ibrand/laravel-wechat-platform:dev-master -vvv
```